### PR TITLE
First cron job added

### DIFF
--- a/cron/.config/.cron/mycron
+++ b/cron/.config/.cron/mycron
@@ -1,0 +1,2 @@
+*/5 * * * * /home/johnny/.local/bin/batterynotify
+


### PR DESCRIPTION

+ Cron job added through "$ crontab -e" and concatinated into a file "$ crontab -l  > /any/path/to/mycron" and runned the command: 

                             $ crontab mycron


... just so that it knows where to look for, it could be manipulated only in the /tmp/ dir ($ crontab -e) and found in /var/, but it makes more sense to keep track of that file where we want and where it's safe to edit