### PR TITLE
more zsh aliases

### DIFF
--- a/nvim/.config/nvim/after/plugin/lua_snip.lua
+++ b/nvim/.config/nvim/after/plugin/lua_snip.lua
@@ -170,6 +170,15 @@ ls.add_snippets('typescriptreact', {
     })
 })
 
+ls.add_snippets('typescript', {
+    s('try', {
+        t({ 'try {', '    ' }),
+        i(1),
+        t({ '    ', '} catch(err) {', '' }),
+        t({ '    console.log(err)', '}' })
+    })
+})
+
 ls.add_snippets('typescriptreact', {
     s('us', {
         t("const ["),

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -56,6 +56,7 @@ export MOZILLA_HOME=~/.config/.mozilla
 # Aliases
 alias src="source ~/.zshrc"
 alias nv="nvim"
+alias v="nvim ."
 alias kill="kill -9"
 alias ls="ls -m --color=auto"
 alias ll="ls -l"
@@ -74,6 +75,7 @@ alias wifimenu=~/.dotfiles/local/.local/bin/wifimenu
 alias screenadd=~/.dotfiles/local/.local/bin/screenadd
 alias changekeyboardlayout=~/.dotfiles/local/.local/bin/changekeyboardlayout
 alias cat="bat"
+alias dot="cd ~/.dotfiles"
 
 # Set to vi mode in cli
 set -o vi


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
