### PR TITLE
alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ local/.local/share/recently-used.xbel
 
 local/.local/bin/bluetoothheadphones
 
+local/.local/bin/projectstart
+
 local/.local/bin/connectserver
 
 nvim/.config/nvim/lazy-lock.json

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -78,6 +78,7 @@ alias changekeyboardlayout=~/.dotfiles/local/.local/bin/changekeyboardlayout
 alias cat="bat"
 alias dot="cd ~/.dotfiles"
 alias server='xdotool key --clearmodifiers Super+t && exit'
+alias planner='~/.dotfiles/local/.local/bin/projectstart && exit' 
 
 # Set to vi mode in cli
 set -o vi


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
