### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/after/plugin/diagnostics.lua
+++ b/nvim/.config/nvim/after/plugin/diagnostics.lua
@@ -13,7 +13,7 @@ vim.diagnostic.config({
     },
 })
 
-vim.api.nvim_set_keymap('n', '<leader>do', '<cmd>lua vim.diagnostic.open_float()<CR>zz2<C-e>',
+vim.api.nvim_set_keymap('n', '<leader>do', '<cmd>lua vim.diagnostic.open_float()<CR>zz',
     { noremap = true, silent = true })
 vim.api.nvim_set_keymap('n', '<leader>dp', '<cmd>lua vim.diagnostic.goto_prev()<CR>zz',
     { noremap = true, silent = true })

--- a/nvim/.config/nvim/lua/config-johnny/remap.lua
+++ b/nvim/.config/nvim/lua/config-johnny/remap.lua
@@ -10,6 +10,7 @@ vim.keymap.set("n", "<leader>w", function()
     vim.cmd('w')
 end)
 
+
 -- Center screen y position
 vim.keymap.set("n", "zz", "zz")
 vim.keymap.set("n", "<C-d>", "<C-d>zz")
@@ -37,7 +38,12 @@ vim.keymap.set("n", "<leader>d", '')
 
 -- Greatest remap ever
 vim.keymap.set("x", "p", "\"_dP")
+
+-- Replaces the current registry in all file
 vim.keymap.set("n", "<leader>r", [[:%s/\<<C-r><C-w>\>/<C-r><C-w>/gI<Left><Left><Left>]])
+
+-- Searches for the current word and activates cgn so that we can replace the next occurences
+vim.keymap.set('n', 'cgn', '*#cgn')
 
 -- Save all when nvim is suspended
 vim.keymap.set("n", "<Control>z", "<Cmd>wa<CR><Control>z")


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
