### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/after/plugin/marks.lua
+++ b/nvim/.config/nvim/after/plugin/marks.lua
@@ -1,0 +1,34 @@
+require'marks'.setup {
+  -- whether to map keybinds or not. default true
+  default_mappings = true,
+  -- which builtin marks to show. default {}
+  builtin_marks = { ".", "<", ">", "^" },
+  -- whether movements cycle back to the beginning/end of buffer. default true
+  cyclic = true,
+  -- whether the shada file is updated after modifying uppercase marks. default false
+  force_write_shada = false,
+  -- how often (in ms) to redraw signs/recompute mark positions. 
+  -- higher values will have better performance but may cause visual lag, 
+  -- while lower values may cause performance penalties. default 150.
+  refresh_interval = 250,
+  -- sign priorities for each type of mark - builtin marks, uppercase marks, lowercase
+  -- marks, and bookmarks.
+  -- can be either a table with all/none of the keys, or a single number, in which case
+  -- the priority applies to all marks.
+  -- default 10.
+  sign_priority = { lower=10, upper=15, builtin=8, bookmark=20 },
+  -- disables mark tracking for specific filetypes. default {}
+  excluded_filetypes = {},
+  -- marks.nvim allows you to configure up to 10 bookmark groups, each with its own
+  -- sign/virttext. Bookmarks can be used to group together positions and quickly move
+  -- across multiple buffers. default sign is '!@#$%^&*()' (from 0 to 9), and
+  -- default virt_text is "".
+  bookmark_0 = {
+    sign = "⚑",
+    virt_text = "hello world",
+    -- explicitly prompt for a virtual line annotation when setting a bookmark from this group.
+    -- defaults to false.
+    annotate = false,
+  },
+  mappings = {}
+}

--- a/nvim/.config/nvim/lua/config-johnny/lazy.lua
+++ b/nvim/.config/nvim/lua/config-johnny/lazy.lua
@@ -83,6 +83,9 @@ local plugins = {
     -- Git signs
     'lewis6991/gitsigns.nvim',
 
+    -- Visual marks
+    { 'chentoast/marks.nvim' },
+
 }
 
 

--- a/nvim/.config/nvim/lua/config-johnny/remap.lua
+++ b/nvim/.config/nvim/lua/config-johnny/remap.lua
@@ -45,8 +45,8 @@ vim.keymap.set("n", "<leader>r", [[:%s/\<<C-r><C-w>\>/<C-r><C-w>/gI<Left><Left><
 vim.keymap.set('n', 'cgn', '*#cgn')
 
 -- Incremental search trough quickfix list
-vim.keymap.set('n', '<C-n>', ':cnext')
-vim.keymap.set('n', '<C-N>', ':cprevious')
+vim.keymap.set('n', '<C-n>', '<Cmd>cnext<CR>')
+vim.keymap.set('n', '<C-N>', '<Cmd>cprevious<CR>')
 
 -- Save all when nvim is suspended
 vim.keymap.set("n", "<Control>z", "<Cmd>wa<CR><Control>z")


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
- yank also copies to clipboard
- wifimenu password rofi style
- move workspace to another monitor binds
- trouble plugin no longer needed (diagnostics is here to stay)
- re-adding lazy.lua
- Control + c is the same as Esc
- dumb remaps out
- Incremental search through quickfix list keybind
- style: nvim transparency pluggin added
- fix: remap to search through quickfix list now runs
- feat: marks visualizer
