### PR TITLE
development

### DIFF
--- a/local/.local/bin/powermenu
+++ b/local/.local/bin/powermenu
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Power menu script using rofi
+dir="$HOME/.config/rofi/launchers/powermenu_launcher"
+theme='style-7'
+
+CHOSEN=$(printf "Lock\nSuspend\nReboot\nShutdown\nLog Out" | rofi -dmenu -theme ${dir}/${theme}.rasi)
+
+case "$CHOSEN" in
+	"Lock") i3lock ;;
+	"Suspend") systemctl suspend-then-hibernate ;;
+	"Reboot") reboot ;;
+	"Shutdown") poweroff ;;
+	"Log Out") hyprctl dispatch exit ;;
+	*) exit 1 ;;
+esac

--- a/rofi/.config/rofi/launchers/powermenu_launcher/launcher.sh
+++ b/rofi/.config/rofi/launchers/powermenu_launcher/launcher.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+## Author : Aditya Shakya (adi1090x)
+## Github : @adi1090x
+#
+## Rofi   : Launcher (Modi Drun, Run, File Browser, Window)
+#
+## Available Styles
+#
+## style-1     style-2     style-3     style-4     style-5
+## style-6     style-7     style-8     style-9     style-10
+
+dir="$HOME/.config/rofi/launchers/powermenu_launcher"
+theme='style-7'
+
+## Run
+rofi \
+    -show power-menu \
+    -theme ${dir}/${theme}.rasi
+

--- a/rofi/.config/rofi/launchers/powermenu_launcher/style-7.rasi
+++ b/rofi/.config/rofi/launchers/powermenu_launcher/style-7.rasi
@@ -1,0 +1,203 @@
+/**
+ *
+ * Author : Aditya Shakya (adi1090x)
+ * Github : @adi1090x
+ * 
+ * Rofi Theme File
+ * Rofi Version: 1.7.3
+ **/
+
+/*****----- Configuration -----*****/
+configuration {
+	modi:                       "drun,run,filebrowser,window";
+    show-icons:                 false;
+    display-drun:               "";
+    display-run:                "";
+    display-filebrowser:        "";
+    display-window:             "";
+	drun-display-format:        "{name}";
+	window-format:              "{w} · {c} · {t}";
+}
+
+/*****----- Global Properties -----*****/
+* {
+    font:                        "JetBrains Mono Nerd Font 10";
+    background:                  #101010;
+    background-alt:              #252525;
+    foreground:                  #FFFFFF;
+    selected:                    #505050;
+    active:                      #909090;
+    urgent:                      #707070;
+}
+
+/*****----- Main Window -----*****/
+window {
+    /* properties for window widget */
+    transparency:                "real";
+    location:                    center;
+    anchor:                      center;
+    fullscreen:                  false;
+    width:                       400px;
+    x-offset:                    0px;
+    y-offset:                    0px;
+
+    /* properties for all widgets */
+    enabled:                     true;
+    border-radius:               20px;
+    cursor:                      "default";
+    background-color:            @background;
+}
+
+/*****----- Main Box -----*****/
+mainbox {
+    enabled:                     true;
+    spacing:                     0px;
+    background-color:            transparent;
+    orientation:                 vertical;
+    children:                    [ "inputbar", "listbox" ];
+}
+
+listbox {
+    spacing:                     20px;
+    padding:                     20px;
+    background-color:            transparent;
+    orientation:                 vertical;
+    children:                    [ "message", "listview", "mode-switcher" ];
+}
+
+/*****----- Inputbar -----*****/
+inputbar {
+    enabled:                     true;
+    spacing:                     10px;
+    padding:                     100px 40px;
+    background-color:            transparent;
+    background-image:            url("~/.config/rofi/images/g.png", width);
+    text-color:                  @foreground;
+    orientation:                 horizontal;
+    children:                    [ "textbox-prompt-colon", "entry" ];
+}
+textbox-prompt-colon {
+    enabled:                     true;
+    expand:                      false;
+    str:                         "";
+    padding:                     12px 15px;
+    border-radius:               100%;
+    background-color:            @background-alt;
+    text-color:                  inherit;
+}
+entry {
+    enabled:                     true;
+    expand:                      true;
+    padding:                     12px 16px;
+    border-radius:               100%;
+    background-color:            @background-alt;
+    text-color:                  inherit;
+    cursor:                      text;
+    placeholder:                 "Search";
+    placeholder-color:           inherit;
+}
+
+/*****----- Mode Switcher -----*****/
+mode-switcher{
+    enabled:                     true;
+    spacing:                     10px;
+    background-color:            transparent;
+    text-color:                  @foreground;
+}
+button {
+    padding:                     12px;
+    border-radius:               100%;
+    background-color:            @background-alt;
+    text-color:                  inherit;
+    cursor:                      pointer;
+}
+button selected {
+    background-color:            @selected;
+    text-color:                  @foreground;
+}
+
+/*****----- Listview -----*****/
+listview {
+    enabled:                     true;
+    columns:                     1;
+    lines:                       5;
+    cycle:                       true;
+    dynamic:                     true;
+    scrollbar:                   false;
+    layout:                      vertical;
+    reverse:                     false;
+    fixed-height:                true;
+    fixed-columns:               true;
+    
+    spacing:                     10px;
+    background-color:            transparent;
+    text-color:                  @foreground;
+    cursor:                      "default";
+}
+
+/*****----- Elements -----*****/
+element {
+    enabled:                     true;
+    spacing:                     10px;
+    padding:                     12px;
+    border-radius:               100%;
+    background-color:            transparent;
+    text-color:                  @foreground;
+    cursor:                      pointer;
+}
+element normal.normal {
+    background-color:            inherit;
+    text-color:                  inherit;
+}
+element normal.urgent {
+    background-color:            @urgent;
+    text-color:                  @foreground;
+}
+element normal.active {
+    background-color:            @active;
+    text-color:                  @foreground;
+}
+element selected.normal {
+    background-color:            @selected;
+    text-color:                  @foreground;
+}
+element selected.urgent {
+    background-color:            @urgent;
+    text-color:                  @foreground;
+}
+element selected.active {
+    background-color:            @urgent;
+    text-color:                  @foreground;
+}
+element-icon {
+    background-color:            transparent;
+    text-color:                  inherit;
+    size:                        32px;
+    cursor:                      inherit;
+}
+element-text {
+    background-color:            transparent;
+    text-color:                  inherit;
+    cursor:                      inherit;
+    vertical-align:              0.5;
+    horizontal-align:            0.0;
+}
+
+/*****----- Message -----*****/
+message {
+    background-color:            transparent;
+}
+textbox {
+    padding:                     12px;
+    border-radius:               100%;
+    background-color:            @background-alt;
+    text-color:                  @foreground;
+    vertical-align:              0.5;
+    horizontal-align:            0.0;
+}
+error-message {
+    padding:                     15px;
+    border-radius:               0px;
+    background-color:            @background;
+    text-color:                  @foreground;
+}


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
- yank also copies to clipboard
- wifimenu password rofi style
- move workspace to another monitor binds
- trouble plugin no longer needed (diagnostics is here to stay)
- re-adding lazy.lua
- Control + c is the same as Esc
- dumb remaps out
- Incremental search through quickfix list keybind
- style: nvim transparency pluggin added
- fix: remap to search through quickfix list now runs
- feat: marks visualizer
- chore: pnpm installed
- chore: marks plugin removed
- feat: import cost plugin added
- style: nvim's zs -> zs + 50 characters over
- feat: nvim ts auto tag plugin added
- feat: tmux added (conf file + setup script)
- fix: alacritty yml -> toml
- fix: alacritty yml(removed) -> toml
- refactor: cleaning up
- feat: tmux catppuccin + few keybinds
- chore: css lsp
- feat: tmux with colors + catppuccin plugins
- chore: tmux continuum + resurrect
- fix: telescope -> live grep funcion name
- chore: completion to <Tab> + css "{" snippet
- feat: rofi powermenu laucher and style
- feat: powermenu script
