### PR TITLE
development

### DIFF
--- a/i3/.config/i3/config
+++ b/i3/.config/i3/config
@@ -170,7 +170,7 @@ bindsym $mod+Shift+c reload
 # restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
 bindsym $mod+Shift+r restart
 # exit i3 (logs you out of your X session)
-bindsym $mod+Shift+q exec "i3-nagbar -t warning -m 'You pressed the exit shortcut. Do you really want to exit i3? This will end your X session.' -B 'Yes, exit i3' 'i3-msg exit'"
+# bindsym $mod+Shift+q exec "i3-nagbar -t warning -m 'You pressed the exit shortcut. Do you really want to exit i3? This will end your X session.' -B 'Yes, exit i3' 'i3-msg exit'"
 
 # resize window (you can also use the mouse for that)
 mode "resize" {

--- a/local/.local/bin/powermenu
+++ b/local/.local/bin/powermenu
@@ -4,13 +4,13 @@
 dir="$HOME/.config/rofi/launchers/powermenu_launcher"
 theme='style-7'
 
-CHOSEN=$(printf "Lock\nSuspend\nReboot\nShutdown\nLog Out" | rofi -dmenu -theme ${dir}/${theme}.rasi)
+CHOSEN=$(printf " Lock\n Hibernate\n Reboot\n󰐥 Power off\n Log off" | rofi -dmenu -theme ${dir}/${theme}.rasi)
 
 case "$CHOSEN" in
-	"Lock") i3lock ;;
-	"Suspend") systemctl suspend-then-hibernate ;;
-	"Reboot") reboot ;;
-	"Shutdown") poweroff ;;
-	"Log Out") hyprctl dispatch exit ;;
+	" Lock") i3lock ;;
+	" Hibernate") systemctl suspend-then-hibernate ;;
+	" Reboot") reboot ;;
+	"󰐥 Power off") poweroff ;;
+	"  Log off") hyprctl dispatch exit ;;
 	*) exit 1 ;;
 esac

--- a/rofi/.config/rofi/launchers/powermenu_launcher/style-7.rasi
+++ b/rofi/.config/rofi/launchers/powermenu_launcher/style-7.rasi
@@ -21,8 +21,8 @@ configuration {
 
 /*****----- Global Properties -----*****/
 * {
-    font:                        "JetBrains Mono Nerd Font 10";
-    background:                  #101010;
+    font:                        "JetBrains Mono Nerd Font 18";
+    background:                  transparent;
     background-alt:              #252525;
     foreground:                  #FFFFFF;
     selected:                    #505050;
@@ -37,13 +37,13 @@ window {
     location:                    center;
     anchor:                      center;
     fullscreen:                  false;
-    width:                       400px;
+    width:                       320px;
     x-offset:                    0px;
     y-offset:                    0px;
 
     /* properties for all widgets */
     enabled:                     true;
-    border-radius:               20px;
+    border-radius:               5px;
     cursor:                      "default";
     background-color:            @background;
 }
@@ -51,83 +51,32 @@ window {
 /*****----- Main Box -----*****/
 mainbox {
     enabled:                     true;
-    spacing:                     0px;
-    background-color:            transparent;
-    orientation:                 vertical;
-    children:                    [ "inputbar", "listbox" ];
+    spacing:                     4px;
+    background-color:            #426bbf88;
+    orientation:                 horizontal;
+    children:                    [ "listbox" ];
 }
 
 listbox {
     spacing:                     20px;
-    padding:                     20px;
+    padding:                     10px;
     background-color:            transparent;
-    orientation:                 vertical;
-    children:                    [ "message", "listview", "mode-switcher" ];
-}
-
-/*****----- Inputbar -----*****/
-inputbar {
-    enabled:                     true;
-    spacing:                     10px;
-    padding:                     100px 40px;
-    background-color:            transparent;
-    background-image:            url("~/.config/rofi/images/g.png", width);
-    text-color:                  @foreground;
     orientation:                 horizontal;
-    children:                    [ "textbox-prompt-colon", "entry" ];
-}
-textbox-prompt-colon {
-    enabled:                     true;
-    expand:                      false;
-    str:                         "";
-    padding:                     12px 15px;
-    border-radius:               100%;
-    background-color:            @background-alt;
-    text-color:                  inherit;
-}
-entry {
-    enabled:                     true;
-    expand:                      true;
-    padding:                     12px 16px;
-    border-radius:               100%;
-    background-color:            @background-alt;
-    text-color:                  inherit;
-    cursor:                      text;
-    placeholder:                 "Search";
-    placeholder-color:           inherit;
-}
-
-/*****----- Mode Switcher -----*****/
-mode-switcher{
-    enabled:                     true;
-    spacing:                     10px;
-    background-color:            transparent;
-    text-color:                  @foreground;
-}
-button {
-    padding:                     12px;
-    border-radius:               100%;
-    background-color:            @background-alt;
-    text-color:                  inherit;
-    cursor:                      pointer;
-}
-button selected {
-    background-color:            @selected;
-    text-color:                  @foreground;
+    children:                    [ "listview" ];
 }
 
 /*****----- Listview -----*****/
 listview {
     enabled:                     true;
-    columns:                     1;
+    columns:                     2;
     lines:                       5;
     cycle:                       true;
-    dynamic:                     true;
+    dynamic:                     false;
     scrollbar:                   false;
     layout:                      vertical;
     reverse:                     false;
-    fixed-height:                true;
-    fixed-columns:               true;
+    fixed-height:                false;
+    fixed-columns:               false;
     
     spacing:                     10px;
     background-color:            transparent;
@@ -137,10 +86,12 @@ listview {
 
 /*****----- Elements -----*****/
 element {
+    width: 70px;
+    text-align: center;
     enabled:                     true;
     spacing:                     10px;
-    padding:                     12px;
-    border-radius:               100%;
+    padding: 2% 1.4%;
+    border-radius:               15px;
     background-color:            transparent;
     text-color:                  @foreground;
     cursor:                      pointer;
@@ -158,7 +109,7 @@ element normal.active {
     text-color:                  @foreground;
 }
 element selected.normal {
-    background-color:            @selected;
+    background-color:            #5b7ed6;
     text-color:                  @foreground;
 }
 element selected.urgent {
@@ -172,8 +123,11 @@ element selected.active {
 element-icon {
     background-color:            transparent;
     text-color:                  inherit;
-    size:                        32px;
+    size:                        50px;
     cursor:                      inherit;
+    font-size:                   40px;
+    width: 50px;
+    height: 50px;
 }
 element-text {
     background-color:            transparent;
@@ -181,23 +135,9 @@ element-text {
     cursor:                      inherit;
     vertical-align:              0.5;
     horizontal-align:            0.0;
+    size: 50px;
+    font-size:                   40px;
+    width: 50px;
+    height: 50px;
 }
 
-/*****----- Message -----*****/
-message {
-    background-color:            transparent;
-}
-textbox {
-    padding:                     12px;
-    border-radius:               100%;
-    background-color:            @background-alt;
-    text-color:                  @foreground;
-    vertical-align:              0.5;
-    horizontal-align:            0.0;
-}
-error-message {
-    padding:                     15px;
-    border-radius:               0px;
-    background-color:            @background;
-    text-color:                  @foreground;
-}

--- a/sxhkd/.config/sxhkd/sxhkdrc
+++ b/sxhkd/.config/sxhkd/sxhkdrc
@@ -18,10 +18,12 @@ super + t
     ~/.local/bin/connectserver
 
 
+super + shift + q
+    ~/.local/bin/powermenu
+
 # Printscreen
 @Print
         flameshot gui
-
 
 # Brightness
 XF86MonBrightnessUp

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -68,8 +68,8 @@ alias ssh="TERM=xterm-256color $(which ssh)"
 alias ..="cd .."
 alias ...="cd ../.."
 alias ....="cd ../../.."
-alias screenshot="flameshot"
 alias .....="cd ../../../.."
+alias screenshot="flameshot"
 alias brightness=~/.dotfiles/local/.local/bin/changebrightness
 alias blh=~/.dotfiles/local/.local/bin/bluetoothheadphones
 alias wifimenu=~/.dotfiles/local/.local/bin/wifimenu
@@ -80,6 +80,7 @@ alias dot="cd ~/.dotfiles"
 alias server='xdotool key --clearmodifiers Super+t && exit'
 alias planner='~/.dotfiles/local/.local/bin/projectstart && exit' 
 alias tmux='tmux -2'
+alias powermenu="~/.dotfiles/local/.local/bin/powermenu"
 
 # Set to vi mode in cli
 set -o vi


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
- yank also copies to clipboard
- wifimenu password rofi style
- move workspace to another monitor binds
- trouble plugin no longer needed (diagnostics is here to stay)
- re-adding lazy.lua
- Control + c is the same as Esc
- dumb remaps out
- Incremental search through quickfix list keybind
- style: nvim transparency pluggin added
- fix: remap to search through quickfix list now runs
- feat: marks visualizer
- chore: pnpm installed
- chore: marks plugin removed
- feat: import cost plugin added
- style: nvim's zs -> zs + 50 characters over
- feat: nvim ts auto tag plugin added
- feat: tmux added (conf file + setup script)
- fix: alacritty yml -> toml
- fix: alacritty yml(removed) -> toml
- refactor: cleaning up
- feat: tmux catppuccin + few keybinds
- chore: css lsp
- feat: tmux with colors + catppuccin plugins
- chore: tmux continuum + resurrect
- fix: telescope -> live grep funcion name
- chore: completion to <Tab> + css "{" snippet
- feat: rofi powermenu laucher and style
- feat: powermenu script
- feat: powermenu alias
- feat: keybind for powermenu
- feat: powermenu script
- style: powermenu .rasi config
