### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/lua/config-johnny/lazy.lua
+++ b/nvim/.config/nvim/lua/config-johnny/lazy.lua
@@ -92,6 +92,13 @@ local plugins = {
         config = true
     },
 
+    -- Markdow visualizer
+    {
+        "iamcco/markdown-preview.nvim",
+        cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+        ft = { "markdown" },
+        build = function() vim.fn["mkdp#util#install"]() end,
+    },
 
     -- Autotag for frontend sh*t, pls end my suffering
     {

--- a/rofi/.config/rofi/launchers/powermenu_launcher/style-7.rasi
+++ b/rofi/.config/rofi/launchers/powermenu_launcher/style-7.rasi
@@ -52,7 +52,7 @@ window {
 mainbox {
     enabled:                     true;
     spacing:                     4px;
-    background-color:            #426bbf88;
+    background-color:            #1e2030;
     orientation:                 horizontal;
     children:                    [ "listbox" ];
 }
@@ -91,7 +91,7 @@ element {
     enabled:                     true;
     spacing:                     10px;
     padding: 2% 1.4%;
-    border-radius:               15px;
+    border-radius:               10px;
     background-color:            transparent;
     text-color:                  @foreground;
     cursor:                      pointer;


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
- yank also copies to clipboard
- wifimenu password rofi style
- move workspace to another monitor binds
- trouble plugin no longer needed (diagnostics is here to stay)
- re-adding lazy.lua
- Control + c is the same as Esc
- dumb remaps out
- Incremental search through quickfix list keybind
- style: nvim transparency pluggin added
- fix: remap to search through quickfix list now runs
- feat: marks visualizer
- chore: pnpm installed
- chore: marks plugin removed
- feat: import cost plugin added
- style: nvim's zs -> zs + 50 characters over
- feat: nvim ts auto tag plugin added
- feat: tmux added (conf file + setup script)
- fix: alacritty yml -> toml
- fix: alacritty yml(removed) -> toml
- refactor: cleaning up
- feat: tmux catppuccin + few keybinds
- chore: css lsp
- feat: tmux with colors + catppuccin plugins
- chore: tmux continuum + resurrect
- fix: telescope -> live grep funcion name
- chore: completion to <Tab> + css "{" snippet
- feat: rofi powermenu laucher and style
- feat: powermenu script
- feat: powermenu alias
- feat: keybind for powermenu
- feat: powermenu script
- style: powermenu .rasi config
- style: powermenu black background
- feat: nvim markdown plugin
