### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/after/plugin/telescope.lua
+++ b/nvim/.config/nvim/after/plugin/telescope.lua
@@ -17,3 +17,13 @@ vim.keymap.set('n', '<C-p>', builtin.git_files, {})
 vim.keymap.set('n', "<leader>ps", function()
     builtin.grep_string({ search = vim.fn.input("Grep > ") });
 end)
+
+require('telescope').setup {
+    extensions = {
+        file_browser = {
+            theme = "ivy",
+            hijack_netrw = false,
+        }
+    }
+}
+require('telescope').load_extension "file_browser"

--- a/nvim/.config/nvim/after/plugin/telescope.lua
+++ b/nvim/.config/nvim/after/plugin/telescope.lua
@@ -17,13 +17,3 @@ vim.keymap.set('n', '<C-p>', builtin.git_files, {})
 vim.keymap.set('n', "<leader>ps", function()
     builtin.grep_string({ search = vim.fn.input("Grep > ") });
 end)
-
-require('telescope').setup {
-    extensions = {
-        file_browser = {
-            theme = "ivy",
-            hijack_netrw = false,
-        }
-    }
-}
-require('telescope').load_extension "file_browser"

--- a/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
+++ b/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
@@ -1,0 +1,70 @@
+local fb_actions = require "telescope".extensions.file_browser.actions
+require('telescope').setup {
+    extensions = {
+        file_browser = {
+            theme = "ivy",
+            hijack_netrw = false,
+            path = vim.loop.cwd(),
+            cwd = vim.loop.cwd(),
+            cwd_to_path = false,
+            grouped = false,
+            files = true,
+            add_dirs = true,
+            depth = 1,
+            auto_depth = false,
+            select_buffer = false,
+            hidden = { file_browser = false, folder_browser = false },
+            respect_gitignore = vim.fn.executable "fd" == 1,
+            no_ignore = false,
+            follow_symlinks = true,
+            browse_files = require("telescope._extensions.file_browser.finders").browse_files,
+            browse_folders = require("telescope._extensions.file_browser.finders").browse_folders,
+            hide_parent_dir = false,
+            collapse_dirs = false,
+            prompt_path = false,
+            quiet = false,
+            dir_icon = "",
+            dir_icon_hl = "Default",
+            display_stat = { date = true, size = true, mode = true },
+            use_fd = true,
+            git_status = true,
+            mappings = {
+                -- Default keybinds
+                ["i"] = {
+                    ["<A-c>"] = fb_actions.create,
+                    ["<S-CR>"] = fb_actions.create_from_prompt,
+                    ["<A-r>"] = fb_actions.rename,
+                    ["<A-m>"] = fb_actions.move,
+                    ["<A-y>"] = fb_actions.copy,
+                    ["<A-d>"] = fb_actions.remove,
+                    ["<C-o>"] = fb_actions.open,
+                    ["<C-g>"] = fb_actions.goto_parent_dir,
+                    ["<C-e>"] = fb_actions.goto_home_dir,
+                    ["<C-w>"] = fb_actions.goto_cwd,
+                    ["<C-t>"] = fb_actions.change_cwd,
+                    ["<C-f>"] = fb_actions.toggle_browser,
+                    ["<C-h>"] = fb_actions.toggle_hidden,
+                    ["<C-s>"] = fb_actions.toggle_all,
+                    ["<bs>"] = fb_actions.backspace,
+                },
+                -- Default + custom keybinds
+                ["n"] = {
+                    ["c"] = fb_actions.create,          -- Create file/folder at current path (trailing path separator creates folder)
+                    ["r"] = fb_actions.rename,          -- Rename multi-selected files/folders
+                    ["y"] = fb_actions.copy,            -- Copy (multi-)selected files/folders to current path
+                    ["p"] = fb_actions.move,            -- Move multi-selected files/folders to current path
+                    ["<S-d>"] = fb_actions.remove,      -- Delete (multi-)selected files/folders
+                    ["-"] = fb_actions.goto_parent_dir, -- Go to parent directory
+                    ["<C-b>"] = fb_actions.goto_cwd,    -- Go to current working directory (cwd)
+                    ["h"] = fb_actions.toggle_hidden,   -- Toggle hidden files/folders
+                },
+            },
+        },
+    },
+}
+require('telescope').load_extension "file_browser"
+
+vim.api.nvim_set_keymap('n', '<leader>fr', '<Cmd>Telescope file_browser<CR>',
+    { noremap = true })
+vim.api.nvim_set_keymap('n', '<leader>fb', '<Cmd>Telescope file_browser path=%:p:h select_buffer=true<CR>',
+    { noremap = true })

--- a/nvim/.config/nvim/lua/config-johnny/lazy.lua
+++ b/nvim/.config/nvim/lua/config-johnny/lazy.lua
@@ -32,6 +32,12 @@ local plugins = {
         -- or                              , branch = '0.1.x',
         dependencies = { 'nvim-lua/plenary.nvim' }
     },
+
+    -- Telescope file browser
+    {
+        "nvim-telescope/telescope-file-browser.nvim",
+        dependencies = { "nvim-telescope/telescope.nvim", "nvim-lua/plenary.nvim" }
+    },
     -- Harpoon
     "ThePrimeagen/harpoon",
 

--- a/nvim/.config/nvim/lua/config-johnny/lazy.lua
+++ b/nvim/.config/nvim/lua/config-johnny/lazy.lua
@@ -111,6 +111,11 @@ local plugins = {
         'windwp/nvim-ts-autotag'
     },
 
+    -- Icons (for telescope file_browser)
+    {
+        'nvim-tree/nvim-web-devicons'
+    },
+
 }
 
 

--- a/nvim/.config/nvim/lua/config-johnny/remap.lua
+++ b/nvim/.config/nvim/lua/config-johnny/remap.lua
@@ -32,6 +32,8 @@ vim.keymap.set("n", "Y", '"+Y')
 
 -- Control + c is the same as Esc
 vim.keymap.set("n", "<C-c>", '<Esc>')
+vim.keymap.set("i", "<C-c>", '<Esc>')
+vim.keymap.set("x", "<C-c>", '<Esc>')
 
 -- Cutting won't overwrite current paste register
 vim.keymap.set("x", "p", "\"_dP")

--- a/setup.sh
+++ b/setup.sh
@@ -83,6 +83,7 @@ sudo pacman -S neovim &&
 # For fzf
 sudo pacman -S fzf && 
 sudo pacman -S ripgrep && 
+sudo pacman -S fd && 
 
 # Hide mouse bin
 sudo pamcan -S unclutter &&


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
- yank also copies to clipboard
- wifimenu password rofi style
- move workspace to another monitor binds
- trouble plugin no longer needed (diagnostics is here to stay)
- re-adding lazy.lua
- Control + c is the same as Esc
- dumb remaps out
- Incremental search through quickfix list keybind
- style: nvim transparency pluggin added
- fix: remap to search through quickfix list now runs
- feat: marks visualizer
- chore: pnpm installed
- chore: marks plugin removed
- feat: import cost plugin added
- style: nvim's zs -> zs + 50 characters over
- feat: nvim ts auto tag plugin added
- feat: tmux added (conf file + setup script)
- fix: alacritty yml -> toml
- fix: alacritty yml(removed) -> toml
- refactor: cleaning up
- feat: tmux catppuccin + few keybinds
- chore: css lsp
- feat: tmux with colors + catppuccin plugins
- chore: tmux continuum + resurrect
- fix: telescope -> live grep funcion name
- chore: completion to <Tab> + css "{" snippet
- feat: rofi powermenu laucher and style
- feat: powermenu script
- feat: powermenu alias
- feat: keybind for powermenu
- feat: powermenu script
- style: powermenu .rasi config
- style: powermenu black background
- feat: nvim markdown plugin
- feat: telescope file browser
- feat: icons for nvim (telescope file_browser)
- chore: telescope_file_browser config + keybinds
