### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
+++ b/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
@@ -52,10 +52,10 @@ require('telescope').setup {
                     ["c"] = fb_actions.create,          -- Create file/folder at current path (trailing path separator creates folder)
                     ["r"] = fb_actions.rename,          -- Rename multi-selected files/folders
                     ["y"] = fb_actions.copy,            -- Copy (multi-)selected files/folders to current path
-                    ["p"] = fb_actions.move,            -- Move multi-selected files/folders to current path
+                    ["m"] = fb_actions.move,            -- Move multi-selected files/folders to current path
                     ["<S-d>"] = fb_actions.remove,      -- Delete (multi-)selected files/folders
                     ["-"] = fb_actions.goto_parent_dir, -- Go to parent directory
-                    ["<C-b>"] = fb_actions.goto_cwd,    -- Go to current working directory (cwd)
+                    ["<S-b>"] = fb_actions.goto_cwd,    -- Go to current working directory (cwd)
                     ["h"] = fb_actions.toggle_hidden,   -- Toggle hidden files/folders
                 },
             },

--- a/nvim/.config/nvim/lua/config-johnny/lazy.lua
+++ b/nvim/.config/nvim/lua/config-johnny/lazy.lua
@@ -111,7 +111,7 @@ local plugins = {
         'windwp/nvim-ts-autotag'
     },
 
-    -- Icons (for telescope file_browser)
+    -- Icons (for telescope)
     {
         'nvim-tree/nvim-web-devicons'
     },

--- a/nvim/.config/nvim/lua/config-johnny/remap.lua
+++ b/nvim/.config/nvim/lua/config-johnny/remap.lua
@@ -7,7 +7,7 @@ vim.keymap.set("n", "<leader>q", vim.cmd.Ex)
 -- Save and format
 vim.keymap.set("n", "<leader>w", function()
     vim.lsp.buf.format()
-    vim.cmd('w')
+    vim.cmd('wa')
 end)
 
 -- Center screen y position
@@ -34,6 +34,10 @@ vim.keymap.set("n", "Y", '"+Y')
 vim.keymap.set("n", "<C-c>", '<Esc>')
 vim.keymap.set("i", "<C-c>", '<Esc>')
 vim.keymap.set("x", "<C-c>", '<Esc>')
+
+-- Insert line and goes back to normal mode
+vim.keymap.set("n", "<A-o>", 'o<Esc>')
+vim.keymap.set("n", "<A-O>", 'O<Esc>')
 
 -- Cutting won't overwrite current paste register
 vim.keymap.set("x", "p", "\"_dP")


### PR DESCRIPTION
- .gitignore reset
- cursor idle time is 1
- wifimenu script w/ beautiful rofi
- ls alias added
- screen add script fixed
- unbinding f12
- update: transparent background
- Update: change line numbers color
- pt-br keyboard layout added as option
- Autostarts reruns after env refresh
- SSH connects with xterm-256color
- Cat command as Bat
- Comment remap
- Adding Trouble Nvim Plugin
- Adding Cmdline Nvim Plugin
- Adding Noice (UI enhancer) to Nvim
- <leader>w now formats and saves
- Exited 0 before end
- Lualine Added and Moded
- Brightness changes 5 by time
- Script screenadd enhanced
- Statement Fixed
- Wallpaper set when second screen is added
- Feat: Disable Mouse
- fix: telescope bug
- style: noice taken out
- feat: lua snippets added and working
- more ts/react snippets
- format and save to just format
- <leader>w formats and saves
- div snippet for typescriptreact
- button snippet for typescriptreact
- useState and useEffect snippets added
- label snippet for typescriptreact
- pastes and keeps when cuts
- more remaps + deletion of multicursor plugin
- surround plugin + remaps
- relocating remaps
- try catch snippet
- nvim alias + quick cd to ~/.dotfiles
- console.log() snippet... yeah
- enhancing debugging experience
- remaps to center y position of screen
- git signs plugin added
- fix trouble command
- remaps
- fugitive finally added
- live greps now working (ripgrep package required)
- centering keymaps (diagnostics + zs)
- grep string in only git files fn + cmd
- git flow command
- corner less rounded
- some more bins to default system
- connect to server command/script
- alias to connect to server script
- ignoring server script for now on
- fix: dir typo
- refreshing gitignore cache
- adding bluetooth connect and server connect files
- git ignore
- git ignoring files
- keybind to launch server
- workaround command to active the server script keybind
- gitignoring projectstart script
- adding project start bash script alias
- cgn + diagnostic remap
- yank also copies to clipboard
- wifimenu password rofi style
- move workspace to another monitor binds
- trouble plugin no longer needed (diagnostics is here to stay)
- re-adding lazy.lua
- Control + c is the same as Esc
- dumb remaps out
- Incremental search through quickfix list keybind
- style: nvim transparency pluggin added
- fix: remap to search through quickfix list now runs
- feat: marks visualizer
- chore: pnpm installed
- chore: marks plugin removed
- feat: import cost plugin added
- style: nvim's zs -> zs + 50 characters over
- feat: nvim ts auto tag plugin added
- feat: tmux added (conf file + setup script)
- fix: alacritty yml -> toml
- fix: alacritty yml(removed) -> toml
- refactor: cleaning up
- feat: tmux catppuccin + few keybinds
- chore: css lsp
- feat: tmux with colors + catppuccin plugins
- chore: tmux continuum + resurrect
- fix: telescope -> live grep funcion name
- chore: completion to <Tab> + css "{" snippet
- feat: rofi powermenu laucher and style
- feat: powermenu script
- feat: powermenu alias
- feat: keybind for powermenu
- feat: powermenu script
- style: powermenu .rasi config
- style: powermenu black background
- feat: nvim markdown plugin
- feat: telescope file browser
- feat: icons for nvim (telescope file_browser)
- chore: telescope_file_browser config + keybinds
- chore: file_browser remaps
- chore: save + insert new line remap
