### PR TITLE
hdmi notification

### DIFF
--- a/local/.local/bin/hdmiconnected
+++ b/local/.local/bin/hdmiconnected
@@ -1,13 +1,19 @@
 #!/bin/bash
 
+ICONS_PATH="$HOME/.local/share/icons/dunst"
+HDMI_SUCCESS_ICON="hdmi-success-icon.png"
+HDMI_ERROR_ICON="hdmi-error-icon.png"
+
 HDMI_STATUS=$(awk 'NR==1 {print $1}' /sys/class/drm/card1-HDMI-A-1/status)
 
 # Check if HDMI is connected
 if [ $HDMI_STATUS = "connected" ]; then
     echo "HDMI connected"
+    notify-send -u low "HDMI Connected" "HMDI1 is connected" -i "$ICONS_PATH/$HDMI_SUCCESS_ICON" -r 9990
     # Add actions to perform when HDMI is connected
 else
     echo "HDMI disconnected"
+    notify-send -u low "HDMI Disconnected" "HMDI1 is disconnected" -i "$ICONS_PATH/$HDMI_ERROR_ICON"-r 9990
     # Add actions to perform when HDMI is disconnected
 fi
 

--- a/local/.local/bin/screenadd
+++ b/local/.local/bin/screenadd
@@ -3,8 +3,16 @@
 # Check if there is exactly one argument
 if [ $# -ne 1 ]; then
     echo "This command requires exactly 1 argument"
-    echo "Available options: --above, --below, --left-of, --right-of, --same-as"
+    echo -e "Available options:\n --above\n --below\n --left-of\n --right-of\n --same-as"
     exit 1
+fi
+
+CHOSEN_DISPLAY="HDMI1"
+XRANDR_ANSWER=$(xrandr | grep "$CHOSEN_DISPLAY" | awk '/ disconnected / {print $2}')
+
+if [ "$XRANDR_ANSWER" = "disconnected" ]; then
+   echo "Could not find the $CHOSEN_DISPLAY connection" 
+   exit 1 
 fi
 
 # Check if the argument matches one of the specified options


### PR DESCRIPTION
- **.gitignore reset**
- **cursor idle time is 1**
- **wifimenu script w/ beautiful rofi**
- **ls alias added**
- **screen add script fixed**
- **unbinding f12**
- **update: transparent background**
- **Update: change line numbers color**
- **pt-br keyboard layout added as option**
- **Autostarts reruns after env refresh**
- **SSH connects with xterm-256color**
- **Cat command as Bat**
- **Comment remap**
- **Adding Trouble Nvim Plugin**
- **Adding Cmdline Nvim Plugin**
- **Adding Noice (UI enhancer) to Nvim**
- **<leader>w now formats and saves**
- **Exited 0 before end**
- **Lualine Added and Moded**
- **Brightness changes 5 by time**
- **Script screenadd enhanced**
- **Statement Fixed**
- **Wallpaper set when second screen is added**
- **Feat: Disable Mouse**
- **fix: telescope bug**
- **style: noice taken out**
- **feat: lua snippets added and working**
- **more ts/react snippets**
- **format and save to just format**
- **<leader>w formats and saves**
- **div snippet for typescriptreact**
- **button snippet for typescriptreact**
- **useState and useEffect snippets added**
- **label snippet for typescriptreact**
- **pastes and keeps when cuts**
- **more remaps + deletion of multicursor plugin**
- **surround plugin + remaps**
- **relocating remaps**
- **try catch snippet**
- **nvim alias + quick cd to ~/.dotfiles**
- **console.log() snippet... yeah**
- **enhancing debugging experience**
- **remaps to center y position of screen**
- **git signs plugin added**
- **fix trouble command**
- **remaps**
- **fugitive finally added**
- **live greps now working (ripgrep package required)**
- **centering keymaps (diagnostics + zs)**
- **grep string in only git files fn + cmd**
- **git flow command**
- **corner less rounded**
- **some more bins to default system**
- **connect to server command/script**
- **alias to connect to server script**
- **ignoring server script for now on**
- **fix: dir typo**
- **refreshing gitignore cache**
- **adding bluetooth connect and server connect files**
- **git ignore**
- **git ignoring files**
- **keybind to launch server**
- **workaround command to active the server script keybind**
- **gitignoring projectstart script**
- **adding project start bash script alias**
- **cgn + diagnostic remap**
- **yank also copies to clipboard**
- **wifimenu password rofi style**
- **move workspace to another monitor binds**
- **trouble plugin no longer needed (diagnostics is here to stay)**
- **re-adding lazy.lua**
- **Control + c is the same as Esc**
- **dumb remaps out**
- **Incremental search through quickfix list keybind**
- **style: nvim transparency pluggin added**
- **fix: remap to search through quickfix list now runs**
- **feat: marks visualizer**
- **chore: pnpm installed**
- **chore: marks plugin removed**
- **feat: import cost plugin added**
- **style: nvim's zs -> zs + 50 characters over**
- **feat: nvim ts auto tag plugin added**
- **feat: tmux added (conf file + setup script)**
- **fix: alacritty yml -> toml**
- **fix: alacritty yml(removed) -> toml**
- **refactor: cleaning up**
- **feat: tmux catppuccin + few keybinds**
- **chore: css lsp**
- **feat: tmux with colors + catppuccin plugins**
- **chore: tmux continuum + resurrect**
- **fix: telescope -> live grep funcion name**
- **chore: completion to <Tab> + css "{" snippet**
- **feat: rofi powermenu laucher and style**
- **feat: powermenu script**
- **feat: powermenu alias**
- **feat: keybind for powermenu**
- **feat: powermenu script**
- **style: powermenu .rasi config**
- **style: powermenu black background**
- **feat: nvim markdown plugin**
- **feat: telescope file browser**
- **feat: icons for nvim (telescope file_browser)**
- **chore: telescope_file_browser config + keybinds**
- **chore: file_browser remaps**
- **chore: save + insert new line remap**
- **feat: udev rules (powersave + brightness)**
- **feat: hdmi-detect udev rule file**
- **feat: hdmiconnect script file (for udev rule)**
- **feat: eslint + lsp config**
- **feat: save and format are separate ('cause of linter)**
- **chore: eslint separate file**
- **chore: check if there is an HDMI connection**
- **feat: notify-sends hdmiconnected script (bind to udev)**
