### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/after/plugin/lua_snip.lua
+++ b/nvim/.config/nvim/after/plugin/lua_snip.lua
@@ -78,17 +78,38 @@ ls.add_snippets('css', {
     }),
 }, {
     type = "autosnippets",
-    key = "all_auto",
+    key = "css-braces", -- unique id
 })
 
--- ls.add_snippets("all", {
---     s("autotrigger", {
---         t("autosnippet"),
---     }),
--- }, {
---     type = "autosnippets",
---     key = "all_auto",
--- })
+ls.add_snippets("all", {
+    s("{}", {
+        t("{"),
+        i(1),
+        t("}"),
+    }),
+}, {
+    type = "autosnippets",
+})
+
+ls.add_snippets("all", {
+    s("[]", {
+        t("["),
+        i(1),
+        t("]"),
+    }),
+}, {
+    type = "autosnippets",
+})
+
+ls.add_snippets("all", {
+    s("()", {
+        t("("),
+        i(1),
+        t(")"),
+    }),
+}, {
+    type = "autosnippets",
+})
 
 ls.add_snippets('typescriptreact', {
     s('rfun', {

--- a/nvim/.config/nvim/after/plugin/lua_snip.lua
+++ b/nvim/.config/nvim/after/plugin/lua_snip.lua
@@ -1,15 +1,15 @@
 local ls = require("luasnip")
-local fmt = require("luasnip.extras.fmt").fmt
+-- local fmt = require("luasnip.extras.fmt").fmt
 local s = ls.snippet
 -- local sn = ls.snippet_node
 local t = ls.text_node
 local i = ls.insert_node
--- local f = ls.function_node
+local f = ls.function_node
 -- local c = ls.choice_node
 -- local d = ls.dynamic_node
 -- local r = ls.restore_node
 -- local l = require("luasnip.extras").lambda
-local rep = require("luasnip.extras").rep
+-- local rep = require("luasnip.extras").rep
 -- local p = require("luasnip.extras").partial
 -- local m = require("luasnip.extras").match
 -- local n = require("luasnip.extras").nonempty
@@ -21,8 +21,8 @@ local types = require("luasnip.util.types")
 -- local conds_expand = require("luasnip.extras.conditions.expand")
 
 vim.keymap.set({ "i" }, "<C-K>", function() ls.expand() end, { silent = true })
-vim.keymap.set({ "i", "s" }, "<C-L>", function() ls.jump(1) end, { silent = true })
-vim.keymap.set({ "i", "s" }, "<C-J>", function() ls.jump(-1) end, { silent = true })
+vim.keymap.set({ "i", "s" }, "<C-s>", function() ls.jump(1) end, { silent = true })
+vim.keymap.set({ "i", "s" }, "<C-w>", function() ls.jump(-1) end, { silent = true })
 vim.keymap.set('n', '<leader><leader>w',
     "<Cmd>source ~/.dotfiles/nvim/.config/nvim/after/plugin/lua_snip.lua<CR>")
 
@@ -55,21 +55,6 @@ ls.setup({
     end,
 })
 
-function GetScriptFileName()
-    local info = debug.getinfo(2, "S")
-    if info and info.source:sub(1, 1) == "@" then
-        local path = info.source:sub(2)
-        local file = path:match("([^/]+)$")                     -- File name (e.g., file.txt)
-        local fileNameWithoutExtension = file:gsub("%..+$", "") -- File name without extension (e.g., file)
-        return fileNameWithoutExtension
-    else
-        return nil
-    end
-end
-
--- ls.add_snippets('all', {
---     s('<', fmt({ "<{}></{}>", i(1), rep(1) }))
--- })
 ls.add_snippets('css', {
     s("{", {
         t({ "{", "    " }),
@@ -86,6 +71,7 @@ ls.add_snippets("all", {
         t("{"),
         i(1),
         t("}"),
+        i(2)
     }),
 }, {
     type = "autosnippets",
@@ -96,30 +82,66 @@ ls.add_snippets("all", {
         t("["),
         i(1),
         t("]"),
+        i(2)
     }),
 }, {
     type = "autosnippets",
 })
 
 ls.add_snippets("all", {
-    s("()", {
-        t("("),
+    s("''", {
+        t("'"),
         i(1),
-        t(")"),
+        t("'"),
+        i(2)
     }),
 }, {
     type = "autosnippets",
 })
 
-ls.add_snippets('typescriptreact', {
+ls.add_snippets("all", {
+    s('""', {
+        t('"'),
+        i(1),
+        t('"'),
+        i(2)
+    }),
+}, {
+    type = "autosnippets",
+})
+
+ls.add_snippets("all", {
+    s('``', {
+        t('`'),
+        i(1),
+        t('`'),
+        i(2)
+    }),
+}, {
+    type = "autosnippets",
+})
+
+function GetFileName()
+    local fileName = vim.fn.substitute(vim.fn.expand('%:t'), '\\(.*\\)\\..*$', '\\1', '')
+    vim.cmd('normal kj')
+    return (fileName:gsub("[%-_](%w)", function(c)
+        return c:upper()
+    end):gsub("^%l", string.upper))
+end
+
+ls.add_snippets('all', {
     s('rfun', {
         t("export default function "),
-        i(1, 'Compo'),
+        f(GetFileName),
         t({ "() {", "    return (", "        <>", "" }),
-        i(2, "            "),
+        t("            <h1>Hello "),
+        i(1),
+        f(GetFileName),
+        t("</h1>"),
         t({ "", "        </>", "    )", "}" })
     })
 })
+
 
 ls.add_snippets('typescriptreact', {
     s('af', {
@@ -147,35 +169,6 @@ ls.add_snippets('typescriptreact', {
     })
 })
 
-ls.add_snippets('typescriptreact', {
-    s('us', {
-        t("const ["),
-        i(1),
-        t(", "),
-        i(2),
-        t("] = useState("),
-        i(3),
-        t(")"),
-    })
-})
-
-ls.add_snippets('typescriptreact', {
-    s('ue', {
-        t({ "useEffect(() => {", "" }),
-        i(1),
-        t({ "", "}, [])" }),
-    })
-})
-
--- ls.add_snippets("all", {
---     s("autotrigger", {
---         t("autosnippet"),
---     }),
--- }, {
---     type = "autosnippets",
---     key = "all_auto",
--- })
---
 -- require("luasnip.loaders.from_vscode").load({ paths = { "./my-snippets" } }) -- Load snippets from my-snippets folder
 --
 -- require("luasnip.loaders.from_snipmate").load({ path = { "./my-snippets" } })

--- a/nvim/.config/nvim/lua/config-johnny/remap.lua
+++ b/nvim/.config/nvim/lua/config-johnny/remap.lua
@@ -1,6 +1,12 @@
 -- Leader
 vim.g.mapleader = " "
 
+-- vim.keymap.set("n", "<leader>b", function ()
+--     vim.cmd("redir @a | echo substitute(expand('%:t'), '\\(.*\\)\\..*$', '\\1', '') | redir END")
+--     vim.cmd(':normal "ap')
+--     vim.cmd(':normal J')
+-- end)
+
 -- Exit file (default netrw)
 vim.keymap.set("n", "<leader>q", vim.cmd.Ex)
 

--- a/setup.sh
+++ b/setup.sh
@@ -132,6 +132,9 @@ sudo pacman -S flameshot &&
 # Music player
 sudo pacman -S spotify &&
 
+# Business app
+yay -S slack
+
 # Screen brightness manager
 yay -S brillo &&
 


### PR DESCRIPTION
- **.gitignore reset**
- **cursor idle time is 1**
- **wifimenu script w/ beautiful rofi**
- **ls alias added**
- **screen add script fixed**
- **unbinding f12**
- **update: transparent background**
- **Update: change line numbers color**
- **pt-br keyboard layout added as option**
- **Autostarts reruns after env refresh**
- **SSH connects with xterm-256color**
- **Cat command as Bat**
- **Comment remap**
- **Adding Trouble Nvim Plugin**
- **Adding Cmdline Nvim Plugin**
- **Adding Noice (UI enhancer) to Nvim**
- **<leader>w now formats and saves**
- **Exited 0 before end**
- **Lualine Added and Moded**
- **Brightness changes 5 by time**
- **Script screenadd enhanced**
- **Statement Fixed**
- **Wallpaper set when second screen is added**
- **Feat: Disable Mouse**
- **fix: telescope bug**
- **style: noice taken out**
- **feat: lua snippets added and working**
- **more ts/react snippets**
- **format and save to just format**
- **<leader>w formats and saves**
- **div snippet for typescriptreact**
- **button snippet for typescriptreact**
- **useState and useEffect snippets added**
- **label snippet for typescriptreact**
- **pastes and keeps when cuts**
- **more remaps + deletion of multicursor plugin**
- **surround plugin + remaps**
- **relocating remaps**
- **try catch snippet**
- **nvim alias + quick cd to ~/.dotfiles**
- **console.log() snippet... yeah**
- **enhancing debugging experience**
- **remaps to center y position of screen**
- **git signs plugin added**
- **fix trouble command**
- **remaps**
- **fugitive finally added**
- **live greps now working (ripgrep package required)**
- **centering keymaps (diagnostics + zs)**
- **grep string in only git files fn + cmd**
- **git flow command**
- **corner less rounded**
- **some more bins to default system**
- **connect to server command/script**
- **alias to connect to server script**
- **ignoring server script for now on**
- **fix: dir typo**
- **refreshing gitignore cache**
- **adding bluetooth connect and server connect files**
- **git ignore**
- **git ignoring files**
- **keybind to launch server**
- **workaround command to active the server script keybind**
- **gitignoring projectstart script**
- **adding project start bash script alias**
- **cgn + diagnostic remap**
- **yank also copies to clipboard**
- **wifimenu password rofi style**
- **move workspace to another monitor binds**
- **trouble plugin no longer needed (diagnostics is here to stay)**
- **re-adding lazy.lua**
- **Control + c is the same as Esc**
- **dumb remaps out**
- **Incremental search through quickfix list keybind**
- **style: nvim transparency pluggin added**
- **fix: remap to search through quickfix list now runs**
- **feat: marks visualizer**
- **chore: pnpm installed**
- **chore: marks plugin removed**
- **feat: import cost plugin added**
- **style: nvim's zs -> zs + 50 characters over**
- **feat: nvim ts auto tag plugin added**
- **feat: tmux added (conf file + setup script)**
- **fix: alacritty yml -> toml**
- **fix: alacritty yml(removed) -> toml**
- **refactor: cleaning up**
- **feat: tmux catppuccin + few keybinds**
- **chore: css lsp**
- **feat: tmux with colors + catppuccin plugins**
- **chore: tmux continuum + resurrect**
- **fix: telescope -> live grep funcion name**
- **chore: completion to <Tab> + css "{" snippet**
- **feat: rofi powermenu laucher and style**
- **feat: powermenu script**
- **feat: powermenu alias**
- **feat: keybind for powermenu**
- **feat: powermenu script**
- **style: powermenu .rasi config**
- **style: powermenu black background**
- **feat: nvim markdown plugin**
- **feat: telescope file browser**
- **feat: icons for nvim (telescope file_browser)**
- **chore: telescope_file_browser config + keybinds**
- **chore: file_browser remaps**
- **chore: save + insert new line remap**
- **feat: udev rules (powersave + brightness)**
- **feat: hdmi-detect udev rule file**
- **feat: hdmiconnect script file (for udev rule)**
- **feat: eslint + lsp config**
- **feat: save and format are separate ('cause of linter)**
- **chore: eslint separate file**
- **chore: check if there is an HDMI connection**
- **feat: notify-sends hdmiconnected script (bind to udev)**
- **chore: separated script for adding walppapper**
- **referencing wallpaper script to restart i3**
- **bun installed**
- **deleting import-cost**
- **feat: () [] {} snippet**
- **feat: react component snippet based on file name**
