### PR TITLE
development

### DIFF
--- a/nvim/.config/nvim/after/plugin/lua_snip.lua
+++ b/nvim/.config/nvim/after/plugin/lua_snip.lua
@@ -89,6 +89,17 @@ ls.add_snippets("all", {
 })
 
 ls.add_snippets("all", {
+    s("()", {
+        t("("),
+        i(1),
+        t(")"),
+        i(2)
+    }),
+}, {
+    type = "autosnippets",
+})
+
+ls.add_snippets("all", {
     s("''", {
         t("'"),
         i(1),
@@ -129,7 +140,7 @@ function GetFileName()
     end):gsub("^%l", string.upper))
 end
 
-ls.add_snippets('all', {
+ls.add_snippets('typescriptreact', {
     s('rfun', {
         t("export default function "),
         f(GetFileName),

--- a/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
+++ b/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
@@ -69,7 +69,7 @@ local create = function(file, finder)
     if file then
         if check_file_extension(file.filename) == 'tsx' then
             local declaration = "export default function " .. get_file_name(file.filename) .. "(){\n"
-            local return_html = "\t return (\n\t\t<>\n\t\t\t<h1>Hello " .. get_file_name(file.filename) .. "</h1>\n\t\t</>\n\t)\n}"
+            local return_html = "    return (\n\t\t<>\n\t\t\t<h1>Hello " .. get_file_name(file.filename) .. "</h1>\n\t\t</>\n\t)\n}"
             local textToAppend = declaration .. return_html
             file:write(textToAppend, "a")
             file:close()

--- a/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
+++ b/nvim/.config/nvim/after/plugin/telescope_file_browser.lua
@@ -1,4 +1,105 @@
 local fb_actions = require "telescope".extensions.file_browser.actions
+local fb_utils = require "telescope._extensions.file_browser.utils"
+local Path = require "plenary.path"
+local os_sep = Path.path.sep
+local action_state = require "telescope.actions.state"
+local async = require "plenary.async"
+
+local get_target_dir = function(finder)
+  local entry_path
+  if finder.files == false then
+    local entry = action_state.get_selected_entry()
+    entry_path = entry and entry.value -- absolute path
+  end
+  return finder.files and finder.path or entry_path
+end
+
+local function get_input(opts, callback)
+  local fb_config = require "telescope._extensions.file_browser.config"
+  if fb_config.values.use_ui_input then
+    vim.ui.input(opts, callback)
+  else
+    async.run(function()
+      return vim.fn.input(opts)
+    end, callback)
+  end
+end
+
+local get_file_name = function (path)
+    local separator = "/"
+    local parts = {}
+    for part in string.gmatch(path, "[^"..separator.."]+") do
+        table.insert(parts, part)
+    end
+    return (parts[#parts]:gsub("%..+$", ""):gsub("[%-_](%w)", function(c)
+        return c:upper()
+    end):gsub("^%l", string.upper))
+end
+
+local check_file_extension = function (filename)
+    local dotIndex = filename:find("%.[^%.]*$")
+    if dotIndex then
+        local extension = filename:sub(dotIndex + 1, -1)
+        return extension
+    end
+end
+
+local create = function(file, finder)
+  if not file then
+    return
+  end
+  if
+    file == ""
+    or (finder.files and file == finder.path .. os_sep)
+    or (not finder.files and file == finder.cwd .. os_sep)
+  then
+    fb_utils.notify(
+      "actions.create",
+      { msg = "Please enter a valid file or folder name!", level = "WARN", quiet = finder.quiet }
+    )
+    return
+  end
+  file = Path:new(file)
+  if file:exists() then
+    fb_utils.notify("actions.create", { msg = "Selection already exists!", level = "WARN", quiet = finder.quiet })
+    return
+  end
+  if not fb_utils.is_dir(file.filename) then
+    file:touch { parents = true }
+    if file then
+        if check_file_extension(file.filename) == 'tsx' then
+            local declaration = "export default function " .. get_file_name(file.filename) .. "(){\n"
+            local return_html = "\t return (\n\t\t<>\n\t\t\t<h1>Hello " .. get_file_name(file.filename) .. "</h1>\n\t\t</>\n\t)\n}"
+            local textToAppend = declaration .. return_html
+            file:write(textToAppend, "a")
+            file:close()
+        end
+    else
+        fb_utils.notify("actions.create", { msg = "Could not append text!", level = "WARN", quiet = finder.quiet })
+    end
+  else
+    Path:new(file.filename:sub(1, -2)):mkdir { parents = true, mode = 493 } -- 493 => decimal for mode 0755
+  end
+  return file
+end
+
+local function newly_created_root(path, cwd)
+  local idx
+  local parents = path:parents()
+  cwd = fb_utils.sanitize_path_str(cwd)
+  for i, p in ipairs(parents) do
+    if p == cwd then
+      idx = i
+      break
+    end
+  end
+
+  if idx == nil then
+    return nil
+  end
+  return idx == 1 and path:absolute() or parents[idx - 1]
+end
+
 require('telescope').setup {
     extensions = {
         file_browser = {
@@ -31,6 +132,7 @@ require('telescope').setup {
             mappings = {
                 -- Default keybinds
                 ["i"] = {
+                    -- ["<A-c>"] = fb_actions.create,
                     ["<A-c>"] = fb_actions.create,
                     ["<S-CR>"] = fb_actions.create_from_prompt,
                     ["<A-r>"] = fb_actions.rename,
@@ -49,7 +151,23 @@ require('telescope').setup {
                 },
                 -- Default + custom keybinds
                 ["n"] = {
-                    ["c"] = fb_actions.create,          -- Create file/folder at current path (trailing path separator creates folder)
+                    ["c"] = function(prompt_bufnr)
+                        local current_picker = action_state.get_current_picker(prompt_bufnr)
+                        local finder = current_picker.finder
+
+                        local base_dir = get_target_dir(finder) .. os_sep
+                        get_input({ prompt = "Create: ", default = base_dir, completion = "file" }, function(input)
+                          vim.cmd [[ redraw ]] -- redraw to clear out vim.ui.prompt to avoid hit-enter prompt
+                          local file = create(input, finder)
+                          if file then
+                            local selection_path = newly_created_root(file, base_dir)
+                            if selection_path then
+                              fb_utils.selection_callback(current_picker, selection_path)
+                            end
+                            current_picker:refresh(finder, { reset_prompt = true, multi = current_picker._multi })
+                          end
+                        end)
+                        end, -- Create file/folder at current path (trailing path separator creates folder)
                     ["r"] = fb_actions.rename,          -- Rename multi-selected files/folders
                     ["y"] = fb_actions.copy,            -- Copy (multi-)selected files/folders to current path
                     ["m"] = fb_actions.move,            -- Move multi-selected files/folders to current path
@@ -68,5 +186,3 @@ vim.api.nvim_set_keymap('n', '<leader>fr', '<Cmd>Telescope file_browser<CR><Esc>
     { noremap = true })
 vim.api.nvim_set_keymap('n', '<leader>fb', '<Cmd>Telescope file_browser path=%:p:h select_buffer=true<CR><Esc>',
     { noremap = true })
-
--- vim.cmd("normal qqq")


### PR DESCRIPTION
- **.gitignore reset**
- **cursor idle time is 1**
- **wifimenu script w/ beautiful rofi**
- **ls alias added**
- **screen add script fixed**
- **unbinding f12**
- **update: transparent background**
- **Update: change line numbers color**
- **pt-br keyboard layout added as option**
- **Autostarts reruns after env refresh**
- **SSH connects with xterm-256color**
- **Cat command as Bat**
- **Comment remap**
- **Adding Trouble Nvim Plugin**
- **Adding Cmdline Nvim Plugin**
- **Adding Noice (UI enhancer) to Nvim**
- **<leader>w now formats and saves**
- **Exited 0 before end**
- **Lualine Added and Moded**
- **Brightness changes 5 by time**
- **Script screenadd enhanced**
- **Statement Fixed**
- **Wallpaper set when second screen is added**
- **Feat: Disable Mouse**
- **fix: telescope bug**
- **style: noice taken out**
- **feat: lua snippets added and working**
- **more ts/react snippets**
- **format and save to just format**
- **<leader>w formats and saves**
- **div snippet for typescriptreact**
- **button snippet for typescriptreact**
- **useState and useEffect snippets added**
- **label snippet for typescriptreact**
- **pastes and keeps when cuts**
- **more remaps + deletion of multicursor plugin**
- **surround plugin + remaps**
- **relocating remaps**
- **try catch snippet**
- **nvim alias + quick cd to ~/.dotfiles**
- **console.log() snippet... yeah**
- **enhancing debugging experience**
- **remaps to center y position of screen**
- **git signs plugin added**
- **fix trouble command**
- **remaps**
- **fugitive finally added**
- **live greps now working (ripgrep package required)**
- **centering keymaps (diagnostics + zs)**
- **grep string in only git files fn + cmd**
- **git flow command**
- **corner less rounded**
- **some more bins to default system**
- **connect to server command/script**
- **alias to connect to server script**
- **ignoring server script for now on**
- **fix: dir typo**
- **refreshing gitignore cache**
- **adding bluetooth connect and server connect files**
- **git ignore**
- **git ignoring files**
- **keybind to launch server**
- **workaround command to active the server script keybind**
- **gitignoring projectstart script**
- **adding project start bash script alias**
- **cgn + diagnostic remap**
- **yank also copies to clipboard**
- **wifimenu password rofi style**
- **move workspace to another monitor binds**
- **trouble plugin no longer needed (diagnostics is here to stay)**
- **re-adding lazy.lua**
- **Control + c is the same as Esc**
- **dumb remaps out**
- **Incremental search through quickfix list keybind**
- **style: nvim transparency pluggin added**
- **fix: remap to search through quickfix list now runs**
- **feat: marks visualizer**
- **chore: pnpm installed**
- **chore: marks plugin removed**
- **feat: import cost plugin added**
- **style: nvim's zs -> zs + 50 characters over**
- **feat: nvim ts auto tag plugin added**
- **feat: tmux added (conf file + setup script)**
- **fix: alacritty yml -> toml**
- **fix: alacritty yml(removed) -> toml**
- **refactor: cleaning up**
- **feat: tmux catppuccin + few keybinds**
- **chore: css lsp**
- **feat: tmux with colors + catppuccin plugins**
- **chore: tmux continuum + resurrect**
- **fix: telescope -> live grep funcion name**
- **chore: completion to <Tab> + css "{" snippet**
- **feat: rofi powermenu laucher and style**
- **feat: powermenu script**
- **feat: powermenu alias**
- **feat: keybind for powermenu**
- **feat: powermenu script**
- **style: powermenu .rasi config**
- **style: powermenu black background**
- **feat: nvim markdown plugin**
- **feat: telescope file browser**
- **feat: icons for nvim (telescope file_browser)**
- **chore: telescope_file_browser config + keybinds**
- **chore: file_browser remaps**
- **chore: save + insert new line remap**
- **feat: udev rules (powersave + brightness)**
- **feat: hdmi-detect udev rule file**
- **feat: hdmiconnect script file (for udev rule)**
- **feat: eslint + lsp config**
- **feat: save and format are separate ('cause of linter)**
- **chore: eslint separate file**
- **chore: check if there is an HDMI connection**
- **feat: notify-sends hdmiconnected script (bind to udev)**
- **chore: separated script for adding walppapper**
- **referencing wallpaper script to restart i3**
- **bun installed**
- **deleting import-cost**
- **feat: () [] {} snippet**
- **feat: react component snippet based on file name**
- **feat: creating .tsx appends component boiler plate  - Through telescope_file_browser only  - The .tsx file extension only (for now)  - The component name is based on the filename (card-layout.tsx -> CardLayout)**
- **fix: space/tab issue**
