### PR TITLE
nvim snips

### DIFF
--- a/nvim/.config/nvim/after/plugin/csharp_snip.lua
+++ b/nvim/.config/nvim/after/plugin/csharp_snip.lua
@@ -1,0 +1,28 @@
+local ls = require("luasnip")
+local s = ls.snippet
+local t = ls.text_node
+local i = ls.insert_node
+-- local f = ls.function_node
+
+-- Console.WriteLine() snippet
+ls.add_snippets("cs", {
+  s("cw", {
+    t("Console.WriteLine("), i(1), t(");")
+  })
+})
+
+-- Curly braces go down
+ls.add_snippets("cs", {
+    s("{", {
+        t({
+            "",
+            "{",
+            "    "
+        }),
+        i(1),
+        t({
+            "",
+            "}"
+        })
+    }),
+})

--- a/nvim/.config/nvim/after/plugin/lua_snip.lua
+++ b/nvim/.config/nvim/after/plugin/lua_snip.lua
@@ -57,7 +57,7 @@ ls.setup({
 
 ls.add_snippets('css', {
     s("{", {
-        t({ "{", "    " }),
+        t({ "", "{", "    " }),
         i(1),
         t({ "", "}" })
     }),
@@ -88,49 +88,6 @@ ls.add_snippets("all", {
     type = "autosnippets",
 })
 
-ls.add_snippets("all", {
-    s("()", {
-        t("("),
-        i(1),
-        t(")"),
-        i(2)
-    }),
-}, {
-    type = "autosnippets",
-})
-
-ls.add_snippets("all", {
-    s("''", {
-        t("'"),
-        i(1),
-        t("'"),
-        i(2)
-    }),
-}, {
-    type = "autosnippets",
-})
-
-ls.add_snippets("all", {
-    s('""', {
-        t('"'),
-        i(1),
-        t('"'),
-        i(2)
-    }),
-}, {
-    type = "autosnippets",
-})
-
-ls.add_snippets("all", {
-    s('``', {
-        t('`'),
-        i(1),
-        t('`'),
-        i(2)
-    }),
-}, {
-    type = "autosnippets",
-})
 
 function GetFileName()
     local fileName = vim.fn.substitute(vim.fn.expand('%:t'), '\\(.*\\)\\..*$', '\\1', '')
@@ -150,33 +107,6 @@ ls.add_snippets('typescriptreact', {
         f(GetFileName),
         t("</h1>"),
         t({ "", "        </>", "    )", "}" })
-    })
-})
-
-
-ls.add_snippets('typescriptreact', {
-    s('af', {
-        t("const "),
-        i(1),
-        t(" = () => {"),
-        t({ "", "}" })
-    })
-})
-
-
-ls.add_snippets('typescript', {
-    s('c', {
-        t('console.log('),
-        i(1),
-        t(')')
-    })
-})
-
-ls.add_snippets('typescriptreact', {
-    s('c', {
-        t('console.log('),
-        i(1),
-        t(')')
     })
 })
 

--- a/nvim/.config/nvim/after/plugin/omnisharp.lua
+++ b/nvim/.config/nvim/after/plugin/omnisharp.lua
@@ -1,0 +1,7 @@
+local nvim_lsp = require('lspconfig')
+
+nvim_lsp.omnisharp.setup {
+    cmd = { "omnisharp-mono", "--languageserver", "--hostPID", tostring(vim.fn.getpid()) };
+    filetypes = { "cs", "vb" };
+    root_dir = nvim_lsp.util.root_pattern(".git", "*.sln");
+}

--- a/nvim/.config/nvim/after/plugin/transparent.lua
+++ b/nvim/.config/nvim/after/plugin/transparent.lua
@@ -1,0 +1,1 @@
+-- vim.cmd('TransparentEnable')

--- a/nvim/.config/nvim/lua/config-johnny/remap.lua
+++ b/nvim/.config/nvim/lua/config-johnny/remap.lua
@@ -1,12 +1,6 @@
 -- Leader
 vim.g.mapleader = " "
 
--- vim.keymap.set("n", "<leader>b", function ()
---     vim.cmd("redir @a | echo substitute(expand('%:t'), '\\(.*\\)\\..*$', '\\1', '') | redir END")
---     vim.cmd(':normal "ap')
---     vim.cmd(':normal J')
--- end)
-
 -- Exit file (default netrw)
 vim.keymap.set("n", "<leader>q", vim.cmd.Ex)
 


### PR DESCRIPTION
- **.gitignore reset**
- **cursor idle time is 1**
- **wifimenu script w/ beautiful rofi**
- **ls alias added**
- **screen add script fixed**
- **unbinding f12**
- **update: transparent background**
- **Update: change line numbers color**
- **pt-br keyboard layout added as option**
- **Autostarts reruns after env refresh**
- **SSH connects with xterm-256color**
- **Cat command as Bat**
- **Comment remap**
- **Adding Trouble Nvim Plugin**
- **Adding Cmdline Nvim Plugin**
- **Adding Noice (UI enhancer) to Nvim**
- **<leader>w now formats and saves**
- **Exited 0 before end**
- **Lualine Added and Moded**
- **Brightness changes 5 by time**
- **Script screenadd enhanced**
- **Statement Fixed**
- **Wallpaper set when second screen is added**
- **Feat: Disable Mouse**
- **fix: telescope bug**
- **style: noice taken out**
- **feat: lua snippets added and working**
- **more ts/react snippets**
- **format and save to just format**
- **<leader>w formats and saves**
- **div snippet for typescriptreact**
- **button snippet for typescriptreact**
- **useState and useEffect snippets added**
- **label snippet for typescriptreact**
- **pastes and keeps when cuts**
- **more remaps + deletion of multicursor plugin**
- **surround plugin + remaps**
- **relocating remaps**
- **try catch snippet**
- **nvim alias + quick cd to ~/.dotfiles**
- **console.log() snippet... yeah**
- **enhancing debugging experience**
- **remaps to center y position of screen**
- **git signs plugin added**
- **fix trouble command**
- **remaps**
- **fugitive finally added**
- **live greps now working (ripgrep package required)**
- **centering keymaps (diagnostics + zs)**
- **grep string in only git files fn + cmd**
- **git flow command**
- **corner less rounded**
- **some more bins to default system**
- **connect to server command/script**
- **alias to connect to server script**
- **ignoring server script for now on**
- **fix: dir typo**
- **refreshing gitignore cache**
- **adding bluetooth connect and server connect files**
- **git ignore**
- **git ignoring files**
- **keybind to launch server**
- **workaround command to active the server script keybind**
- **gitignoring projectstart script**
- **adding project start bash script alias**
- **cgn + diagnostic remap**
- **yank also copies to clipboard**
- **wifimenu password rofi style**
- **move workspace to another monitor binds**
- **trouble plugin no longer needed (diagnostics is here to stay)**
- **re-adding lazy.lua**
- **Control + c is the same as Esc**
- **dumb remaps out**
- **Incremental search through quickfix list keybind**
- **style: nvim transparency pluggin added**
- **fix: remap to search through quickfix list now runs**
- **feat: marks visualizer**
- **chore: pnpm installed**
- **chore: marks plugin removed**
- **feat: import cost plugin added**
- **style: nvim's zs -> zs + 50 characters over**
- **feat: nvim ts auto tag plugin added**
- **feat: tmux added (conf file + setup script)**
- **fix: alacritty yml -> toml**
- **fix: alacritty yml(removed) -> toml**
- **refactor: cleaning up**
- **feat: tmux catppuccin + few keybinds**
- **chore: css lsp**
- **feat: tmux with colors + catppuccin plugins**
- **chore: tmux continuum + resurrect**
- **fix: telescope -> live grep funcion name**
- **chore: completion to <Tab> + css "{" snippet**
- **feat: rofi powermenu laucher and style**
- **feat: powermenu script**
- **feat: powermenu alias**
- **feat: keybind for powermenu**
- **feat: powermenu script**
- **style: powermenu .rasi config**
- **style: powermenu black background**
- **feat: nvim markdown plugin**
- **feat: telescope file browser**
- **feat: icons for nvim (telescope file_browser)**
- **chore: telescope_file_browser config + keybinds**
- **chore: file_browser remaps**
- **chore: save + insert new line remap**
- **feat: udev rules (powersave + brightness)**
- **feat: hdmi-detect udev rule file**
- **feat: hdmiconnect script file (for udev rule)**
- **feat: eslint + lsp config**
- **feat: save and format are separate ('cause of linter)**
- **chore: eslint separate file**
- **chore: check if there is an HDMI connection**
- **feat: notify-sends hdmiconnected script (bind to udev)**
- **chore: separated script for adding walppapper**
- **referencing wallpaper script to restart i3**
- **bun installed**
- **deleting import-cost**
- **feat: () [] {} snippet**
- **feat: react component snippet based on file name**
- **feat: creating .tsx appends component boiler plate  - Through telescope_file_browser only  - The .tsx file extension only (for now)  - The component name is based on the filename (card-layout.tsx -> CardLayout)**
- **fix: space/tab issue**
- **lsp: omnisharp for c# development**
- **snip: getting rid of some snippets**
- **remap: getting rid of a remap**
- **snip: c# first snippets**
- **transparent needs the command to run, just not everytime**
