### PR TITLE
dap

### DIFF
--- a/nvim/.config/nvim/after/plugin/dap_csharp.lua
+++ b/nvim/.config/nvim/after/plugin/dap_csharp.lua
@@ -1,0 +1,18 @@
+local dap = require("dap")
+
+dap.adapters.coreclr = {
+    type = 'executable',
+    command = '/home/johnny/.local/share/nvim/mason/packages/netcoredbg/netcoredbg',
+    args = { '--interpreter=vscode' }
+}
+
+dap.configurations.cs = {
+    {
+        type = "coreclr",
+        name = "launch - netcoredbg",
+        request = "launch",
+        aprogram = function()
+            return vim.fn.input('Path to dll', vim.fn.getcwd() .. '/bin/Debug/', 'file')
+        end,
+    },
+}

--- a/nvim/.config/nvim/after/plugin/dap_ui.lua
+++ b/nvim/.config/nvim/after/plugin/dap_ui.lua
@@ -1,0 +1,75 @@
+require("dapui").setup({
+    controls = {
+        element = "repl",
+        enabled = true,
+        icons = {
+            disconnect = "",
+            pause = "",
+            play = "",
+            run_last = "",
+            step_back = "",
+            step_into = "",
+            step_out = "",
+            step_over = "",
+            terminate = ""
+        }
+    },
+    element_mappings = {},
+    expand_lines = true,
+    floating = {
+        border = "single",
+        mappings = {
+            close = { "q", "<Esc>" }
+        }
+    },
+    force_buffers = true,
+    icons = {
+        collapsed = "",
+        current_frame = "",
+        expanded = ""
+    },
+    layouts = { {
+        elements = { {
+            id = "scopes",
+            size = 0.25
+        }, {
+            id = "breakpoints",
+            size = 0.25
+        }, {
+            id = "stacks",
+            size = 0.25
+        }, {
+            id = "watches",
+            size = 0.25
+        } },
+        position = "left",
+        size = 40
+    }, {
+        elements = { {
+            id = "repl",
+            size = 0.5
+        }, {
+            id = "console",
+            size = 0.5
+        } },
+        position = "bottom",
+        size = 10
+    } },
+    mappings = {
+        edit = "e",
+        expand = { "<CR>", "<2-LeftMouse>" },
+        open = "o",
+        remove = "d",
+        repl = "r",
+        toggle = "t"
+    },
+    render = {
+        indent = 1,
+        max_value_lines = 100
+    }
+})
+
+vim.keymap.set("n", "<leader>dap", ":lua require('dapui').toggle()<CR>", { noremap = true })
+vim.keymap.set("n", "<leader>db", ":DapToggleBreakpoint<CR>", { noremap = true })
+vim.keymap.set("n", "<leader>dc", ":DapContinue<CR>", { noremap = true })
+vim.keymap.set("n", "<leader>dr", ":lua require('dapui').open({reset=true})<CR>", { noremap = true })

--- a/nvim/.config/nvim/lua/config-johnny/lazy.lua
+++ b/nvim/.config/nvim/lua/config-johnny/lazy.lua
@@ -1,11 +1,11 @@
-local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+local lazypath = vim.fn.stdpath('data') .. '/lazy/lazy.nvim'
 if not vim.loop.fs_stat(lazypath) then
     vim.fn.system({
-        "git",
-        "clone",
-        "--filter=blob:none",
-        "https://github.com/folke/lazy.nvim.git",
-        "--branch=stable", -- latest stable release
+        'git',
+        'clone',
+        '--filter=blob:none',
+        'https://github.com/folke/lazy.nvim.git',
+        '--branch=stable', -- latest stable release
         lazypath,
     })
 end
@@ -14,15 +14,18 @@ vim.opt.rtp:prepend(lazypath)
 local plugins = {
 
     -- Color scheme
-    { "catppuccin/nvim",           name = "catppuccin" },
+    {
+        'catppuccin/nvim',
+        name = 'catppuccin'
+    },
 
     -- Transparency
-    { "xiyaowong/transparent.nvim" },
+    { 'xiyaowong/transparent.nvim' },
 
     -- Treesiter
     {
         'nvim-treesitter/nvim-treesitter',
-        build = ":TSUpdate"
+        build = ':TSUpdate'
     },
 
     -- Telescope
@@ -35,14 +38,15 @@ local plugins = {
 
     -- Telescope file browser
     {
-        "nvim-telescope/telescope-file-browser.nvim",
-        dependencies = { "nvim-telescope/telescope.nvim", "nvim-lua/plenary.nvim" }
+        'nvim-telescope/telescope-file-browser.nvim',
+        dependencies = { 'nvim-telescope/telescope.nvim', 'nvim-lua/plenary.nvim' }
     },
+
     -- Harpoon
-    "ThePrimeagen/harpoon",
+    'ThePrimeagen/harpoon',
 
     -- Undotree
-    "mbbill/undotree",
+    'mbbill/undotree',
 
     -- LSP
     {
@@ -65,10 +69,19 @@ local plugins = {
         }
     },
 
+    -- DAP
+    {
+        {
+            'rcarriga/nvim-dap-ui',
+            dependencies = { 'mfussenegger/nvim-dap', 'nvim-neotest/nvim-nio' },
+        },
+        { 'theHamsta/nvim-dap-virtual-text' },
+    },
+
     -- Status bar
     {
         'nvim-lualine/lualine.nvim',
-        requires = { 'nvim-tree/nvim-web-devicons', opt = true }
+        dependencies = { 'nvim-tree/nvim-web-devicons', opt = true }
     },
 
     -- Comments
@@ -78,9 +91,9 @@ local plugins = {
     {
         'L3MON4D3/LuaSnip',
         -- follow latest release.
-        version = "2.0.0", -- Replace <CurrentMajor> by the latest released major (first number of latest release)
+        version = '2.0.0', -- Replace <CurrentMajor> by the latest released major (first number of latest release)
         -- install jsregexp (optional!).
-        build = "make install_jsregexp"
+        build = 'make install_jsregexp'
     }, -- Required
 
     -- Vim fugitive
@@ -91,10 +104,10 @@ local plugins = {
 
     -- Markdow visualizer
     {
-        "iamcco/markdown-preview.nvim",
-        cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
-        ft = { "markdown" },
-        build = function() vim.fn["mkdp#util#install"]() end,
+        'iamcco/markdown-preview.nvim',
+        cmd = { 'MarkdownPreviewToggle', 'MarkdownPreview', 'MarkdownPreviewStop' },
+        ft = { 'markdown' },
+        build = function() vim.fn['mkdp#util#install']() end,
     },
 
     -- Autotag for frontend sh*t, pls end my suffering
@@ -106,11 +119,8 @@ local plugins = {
     {
         'nvim-tree/nvim-web-devicons'
     },
-
 }
 
 
-
 local opts = {}
-
-require("lazy").setup(plugins, opts)
+require('lazy').setup(plugins, opts)


### PR DESCRIPTION
- **.gitignore reset**
- **cursor idle time is 1**
- **wifimenu script w/ beautiful rofi**
- **ls alias added**
- **screen add script fixed**
- **unbinding f12**
- **update: transparent background**
- **Update: change line numbers color**
- **pt-br keyboard layout added as option**
- **Autostarts reruns after env refresh**
- **SSH connects with xterm-256color**
- **Cat command as Bat**
- **Comment remap**
- **Adding Trouble Nvim Plugin**
- **Adding Cmdline Nvim Plugin**
- **Adding Noice (UI enhancer) to Nvim**
- **<leader>w now formats and saves**
- **Exited 0 before end**
- **Lualine Added and Moded**
- **Brightness changes 5 by time**
- **Script screenadd enhanced**
- **Statement Fixed**
- **Wallpaper set when second screen is added**
- **Feat: Disable Mouse**
- **fix: telescope bug**
- **style: noice taken out**
- **feat: lua snippets added and working**
- **more ts/react snippets**
- **format and save to just format**
- **<leader>w formats and saves**
- **div snippet for typescriptreact**
- **button snippet for typescriptreact**
- **useState and useEffect snippets added**
- **label snippet for typescriptreact**
- **pastes and keeps when cuts**
- **more remaps + deletion of multicursor plugin**
- **surround plugin + remaps**
- **relocating remaps**
- **try catch snippet**
- **nvim alias + quick cd to ~/.dotfiles**
- **console.log() snippet... yeah**
- **enhancing debugging experience**
- **remaps to center y position of screen**
- **git signs plugin added**
- **fix trouble command**
- **remaps**
- **fugitive finally added**
- **live greps now working (ripgrep package required)**
- **centering keymaps (diagnostics + zs)**
- **grep string in only git files fn + cmd**
- **git flow command**
- **corner less rounded**
- **some more bins to default system**
- **connect to server command/script**
- **alias to connect to server script**
- **ignoring server script for now on**
- **fix: dir typo**
- **refreshing gitignore cache**
- **adding bluetooth connect and server connect files**
- **git ignore**
- **git ignoring files**
- **keybind to launch server**
- **workaround command to active the server script keybind**
- **gitignoring projectstart script**
- **adding project start bash script alias**
- **cgn + diagnostic remap**
- **yank also copies to clipboard**
- **wifimenu password rofi style**
- **move workspace to another monitor binds**
- **trouble plugin no longer needed (diagnostics is here to stay)**
- **re-adding lazy.lua**
- **Control + c is the same as Esc**
- **dumb remaps out**
- **Incremental search through quickfix list keybind**
- **style: nvim transparency pluggin added**
- **fix: remap to search through quickfix list now runs**
- **feat: marks visualizer**
- **chore: pnpm installed**
- **chore: marks plugin removed**
- **feat: import cost plugin added**
- **style: nvim's zs -> zs + 50 characters over**
- **feat: nvim ts auto tag plugin added**
- **feat: tmux added (conf file + setup script)**
- **fix: alacritty yml -> toml**
- **fix: alacritty yml(removed) -> toml**
- **refactor: cleaning up**
- **feat: tmux catppuccin + few keybinds**
- **chore: css lsp**
- **feat: tmux with colors + catppuccin plugins**
- **chore: tmux continuum + resurrect**
- **fix: telescope -> live grep funcion name**
- **chore: completion to <Tab> + css "{" snippet**
- **feat: rofi powermenu laucher and style**
- **feat: powermenu script**
- **feat: powermenu alias**
- **feat: keybind for powermenu**
- **feat: powermenu script**
- **style: powermenu .rasi config**
- **style: powermenu black background**
- **feat: nvim markdown plugin**
- **feat: telescope file browser**
- **feat: icons for nvim (telescope file_browser)**
- **chore: telescope_file_browser config + keybinds**
- **chore: file_browser remaps**
- **chore: save + insert new line remap**
- **feat: udev rules (powersave + brightness)**
- **feat: hdmi-detect udev rule file**
- **feat: hdmiconnect script file (for udev rule)**
- **feat: eslint + lsp config**
- **feat: save and format are separate ('cause of linter)**
- **chore: eslint separate file**
- **chore: check if there is an HDMI connection**
- **feat: notify-sends hdmiconnected script (bind to udev)**
- **chore: separated script for adding walppapper**
- **referencing wallpaper script to restart i3**
- **bun installed**
- **deleting import-cost**
- **feat: () [] {} snippet**
- **feat: react component snippet based on file name**
- **feat: creating .tsx appends component boiler plate  - Through telescope_file_browser only  - The .tsx file extension only (for now)  - The component name is based on the filename (card-layout.tsx -> CardLayout)**
- **fix: space/tab issue**
- **lsp: omnisharp for c# development**
- **snip: getting rid of some snippets**
- **remap: getting rid of a remap**
- **snip: c# first snippets**
- **transparent needs the command to run, just not everytime**
- **nvim: installing dap**
- **nvim: dap-ui default config + keymaps**
- **nvim: dap for c# config (path to mason)**
