### PR TITLE
develop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Stow-based dotfiles for an Arch Linux + Hyprland machine. The repo lives at `~/p
 | `hypr` | `~/.config/hypr/` |
 | `kitty` | `~/.config/kitty/` |
 | `lazygit` | `~/.config/lazygit/` |
+| `mako` | `~/.config/mako/config` |
 | `nvim` | `~/.config/nvim/` |
 | `ssh` | `~/.ssh/config` |
 | `starship` | `~/.config/starship.toml` |
@@ -54,6 +55,6 @@ stow --dir=~/projects/dotfiles --target=$HOME -D <package>
 
 - **Dotfiles is source of truth.** Never edit config files directly on the machine unless you immediately commit the change here too. Since every file is a symlink into this repo, editing via any editor already edits the repo.
 - **README.md and setup.sh must always reflect reality.** When a package is added/removed, a tool changes, or the setup process shifts, update both files immediately — they are living documents, not snapshots.
-- `mako` is managed by omarchy (`~/.config/omarchy/`). Do not stow it.
+- `mako` is stowed from dotfiles. The config includes omarchy's theme via `include=~/.config/omarchy/current/theme/mako.ini`, so omarchy theming still applies — user overrides come after the include.
 - `nvim` has no standalone git repo anymore — this is the only copy.
 - `btop/themes/current.theme` is a symlink to omarchy's theme — that is intentional.

--- a/hypr/.config/hypr/bindings.conf
+++ b/hypr/.config/hypr/bindings.conf
@@ -1,3 +1,6 @@
+# Notifications
+bindd = SUPER, BackSpace, Dismiss notification, exec, makoctl dismiss
+
 # Application bindings
 #bindd = SUPER, RETURN, Terminal, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)"
 bindd = SUPER, RETURN, Terminal, exec, uwsm-app -- xdg-terminal-exec --dir="$(omarchy-cmd-terminal-cwd)"

--- a/mako/.config/mako/config
+++ b/mako/.config/mako/config
@@ -1,0 +1,5 @@
+include=~/.config/omarchy/current/theme/mako.ini
+
+default-timeout=3000
+border-radius=8
+on-button-left=dismiss

--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,0 +1,5 @@
+# ai-profiles: API key path for tools that explicitly source it (e.g. graphify via governance skill).
+# NOT sourced here — keeps ANTHROPIC_API_KEY out of the global env so Claude Code
+# never detects it and never prompts to use it for the session itself.
+export AI_PROFILES_APIKEY_ENV="$HOME/projects/ai-profiles/.secrets/anthropic-apikey/.env"
+unset ANTHROPIC_API_KEY  # enforce — key must never leak into global env

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -131,3 +131,4 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 alias claude-mem='/home/jo/.bun/bin/bun "/home/jo/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs"'
 
 eval $(DISPLAY="" WAYLAND_DISPLAY="" SSH_ASKPASS="" keychain --eval --quiet --nogui ~/.ssh/gh)
+alias claude-care-fullstack="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-fullstack/claude claude --dangerously-skip-permissions"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -44,6 +44,7 @@ alias claude-beo-dashboard="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/be
 alias claude-beo-mobile="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/beo/profile-mobile/claude claude --dangerously-skip-permissions"
 alias claude-care-backend="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-backend/claude claude --dangerously-skip-permissions"
 alias claude-care-frontend="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-frontend/claude claude --dangerously-skip-permissions"
+alias claude-care-fullstack="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-fullstack/claude claude --dangerously-skip-permissions"
 
 
 export TERMINAL=alacritty
@@ -131,4 +132,3 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 alias claude-mem='/home/jo/.bun/bin/bun "/home/jo/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs"'
 
 eval $(DISPLAY="" WAYLAND_DISPLAY="" SSH_ASKPASS="" keychain --eval --quiet --nogui ~/.ssh/gh)
-alias claude-care-fullstack="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-fullstack/claude claude --dangerously-skip-permissions"


### PR DESCRIPTION
- **new zshrc**
- **fix(ssh): add keychain for persistent agent + ssh config for github**
- **chore: migrate from i3/X11 to Hyprland/Wayland**
- **feat(nvim): consolidate nvim config from standalone repo**
- **fix(nvim): remove stale plugins dropped from machine**
- **docs: add CLAUDE.md, README, and claude-linux alias**
- **feat(git): add git as stow package**
- **docs: add git package to maps, enforce README/setup.sh sync rule**
- **fix(setup): rewrite for Hyprland/Wayland, keep X11 as legacy option**
- **ref(zhsrc): ls alias + ls claude_profiles**
- **fix(zsh): aliases**
- **feat(mako): add stow package with rounded corners, shorter timeout, click-to-dismiss**
- **feat(zsh): add claude-care-fullstack alias**
- **feat(zsh): add .zshenv with API key governance safeguard**
