### PR TITLE
develop

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -1,5 +1,5 @@
-# ai-profiles: API key path for tools that explicitly source it (e.g. graphify via governance skill).
+# ai-agents: API key path for tools that explicitly source it (e.g. graphify via governance skill).
 # NOT sourced here — keeps ANTHROPIC_API_KEY out of the global env so Claude Code
 # never detects it and never prompts to use it for the session itself.
-export AI_PROFILES_APIKEY_ENV="$HOME/projects/ai-profiles/.secrets/anthropic-apikey/.env"
+export AI_AGENTS_APIKEY_ENV="$HOME/projects/ai-agents/.secrets/anthropic-apikey/.env"
 unset ANTHROPIC_API_KEY  # enforce — key must never leak into global env

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -34,17 +34,13 @@ alias grep="grep --color=always"
 
 alias ssh-session='eval "$(ssh-agent -s)" && ssh-add $HOME/.ssh/gh'
 
-# ai-profiles
-alias claude-ai-profiles="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/ai-profiles/claude claude --dangerously-skip-permissions"
-alias claude-base="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/base/claude claude --dangerously-skip-permissions"
-alias claude-linux="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/linux/claude claude --dangerously-skip-permissions"
-alias claude-uni="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/uni/claude claude --dangerously-skip-permissions"
-alias claude-obsessia="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/obsessia/claude claude --dangerously-skip-permissions"
-alias claude-beo-dashboard="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/beo/profile-dashboard/claude claude --dangerously-skip-permissions"
-alias claude-beo-mobile="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/beo/profile-mobile/claude claude --dangerously-skip-permissions"
-alias claude-care-backend="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-backend/claude claude --dangerously-skip-permissions"
-alias claude-care-frontend="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-frontend/claude claude --dangerously-skip-permissions"
-alias claude-care-fullstack="CLAUDE_CONFIG_DIR=~/projects/ai-profiles/profiles/care/profile-fullstack/claude claude --dangerously-skip-permissions"
+# ai-agents — LLM-agnostic launcher. Usage: ai <key> [--llm claude|codex] [--rc] [--session <s>] [tool flags] [prompt]
+#   ai uni                              # foreground, claude (default), uni's default_flags
+#   ai uni --model opus --effort high   # flags pass through to the tool
+#   ai uni --llm codex -m gpt-5 "fix"   # launch codex instead (needs agents/uni/codex/)
+#   ai uni --rc [--session dev-uni]     # tmux window + remote control (claude only)
+# Agent keys + per-LLM config live in config/agent-registry.json (run `ai` with no args to list).
+alias ai='/home/jo/projects/ai-agents/scripts/launch-agent.sh'
 
 
 export TERMINAL=alacritty

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -47,6 +47,7 @@ export TERMINAL=alacritty
 
 PS1='%n@%m:%${(#):-%~}%# '
 
+fpath=(~/projects/ai-agents/scripts/completions $fpath)  # ai launcher completion
 autoload -Uz compinit
 compinit
 # End of lines added by compinstall


### PR DESCRIPTION
- **new zshrc**
- **fix(ssh): add keychain for persistent agent + ssh config for github**
- **chore: migrate from i3/X11 to Hyprland/Wayland**
- **feat(nvim): consolidate nvim config from standalone repo**
- **fix(nvim): remove stale plugins dropped from machine**
- **docs: add CLAUDE.md, README, and claude-linux alias**
- **feat(git): add git as stow package**
- **docs: add git package to maps, enforce README/setup.sh sync rule**
- **fix(setup): rewrite for Hyprland/Wayland, keep X11 as legacy option**
- **ref(zhsrc): ls alias + ls claude_profiles**
- **fix(zsh): aliases**
- **feat(mako): add stow package with rounded corners, shorter timeout, click-to-dismiss**
- **feat(zsh): add claude-care-fullstack alias**
- **feat(zsh): add .zshenv with API key governance safeguard**
- **fix(zsh): update ai-agents paths after repo rename (ai-profiles → ai-agents)**
- **feat(zsh): fpath para completion do ai launcher (antes do compinit)**
